### PR TITLE
Channel annotations update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.18
 	github.com/cloudevents/sdk-go/v2 v2.0.0-RC2
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/lxc/lxd v0.0.0-20200502202108-b0fe8375f34e
+	github.com/knative/eventing v0.14.2
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gomega v1.8.1 // indirect
 	go.opencensus.io v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/cpuid v1.2.2/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/knative/build v0.1.2/go.mod h1:/sU74ZQkwlYA5FwYDJhYTy61i/Kn+5eWfln2jDbw3Qo=
+github.com/knative/eventing v0.14.2 h1:NnZvbUq9BdsnzT95jlT538QkpAt39Za0g2+CwuByntk=
+github.com/knative/eventing v0.14.2/go.mod h1:SkBc5JFsl70Fq/Bjc97+uix8759e4ho0imxq8DQm4DA=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -472,8 +474,6 @@ github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac h1:+2b6iGRJe3hvV/yVXrd41yVEjxuFHxasJqDhkIjS4gk=
 github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac/go.mod h1:Frd2bnT3w5FB5q49ENTfVlztJES+1k/7lyWX2+9gq/M=
-github.com/lxc/lxd v0.0.0-20200502202108-b0fe8375f34e h1:AQLpeMqMgXgLdJnvdpL/Zs7UmxjtNw1rvqiduL/8npU=
-github.com/lxc/lxd v0.0.0-20200502202108-b0fe8375f34e/go.mod h1:2BaZflfwsv8a3uy3/Vw+de4Avn4DSrAiqaHJjCIXMV4=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/lxc/lxd/shared/logger"
 
 	"github.com/triggermesh/aws-kinesis-channel/pkg/apis/messaging/v1alpha1"
 	"github.com/triggermesh/aws-kinesis-channel/pkg/kinesisutil"
@@ -327,8 +326,7 @@ func (s *KinesisDispatcher) CreateKinesisSession(ctx context.Context, channel *v
 	if !present {
 		client, err := s.kinesisClient(channel.Name, channel.Spec.AccountRegion, secret)
 		if err != nil {
-			logger.Errorf("Error creating Kinesis session: %v", err)
-			return err
+			return fmt.Errorf("Error creating Kinesis session: %v", err)
 		}
 		s.kinesisSessions[cRef] = stream{
 			StreamName: channel.Name,


### PR DESCRIPTION
Channels created manually may include [required](https://github.com/knative/eventing/blob/master/docs/spec/channel.md#annotation-requirements) `messaging.knative.dev/subscribable: v1beta1` annotation, but channels created by broker doesn't have it, so we set it in controller. Otherwise subscriptions and triggers doesn't work

closes #30 