### PR TITLE
Address lint warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ jobs:
           name: Installing golangci-lint
           command: make install-golangci-lint
       - run:
-          name: Run vet
-          command: make vet
+          name: Run lint
+          command: make lint
       - run:
           name: Run test/cover
           command: make cover

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LDFLAGS            =
 HAS_GOTESTSUM     := $(shell command -v gotestsum;)
 HAS_GOLANGCI_LINT := $(shell command -v golangci-lint;)
 
-.PHONY: help mod-download build install release test coverage lint vet fmt fmt-test image clean
+.PHONY: help mod-download build install release test coverage lint fmt fmt-test image clean
 
 all: build
 
@@ -79,9 +79,6 @@ cover: test ## Generate code coverage
 
 lint: install-golangci-lint ## Lint source files
 	$(GOLINT) $(GOPKGS)
-
-vet: ## Vet source files
-	$(GO) vet $(GOPKGS)
 
 fmt: ## Format source files
 	$(GOFMT) -s -w $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}} {{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}} {{end}}' $(GOPKGS))

--- a/pkg/apis/messaging/register.go
+++ b/pkg/apis/messaging/register.go
@@ -16,7 +16,5 @@ limitations under the License.
 
 package messaging
 
-// GroupName is the group name used in this package
-const (
-	GroupName = "messaging.triggermesh.dev"
-)
+// GroupName is the group name used in this package.
+const GroupName = "messaging.triggermesh.dev"

--- a/pkg/apis/messaging/v1alpha1/kinesis_channel_types.go
+++ b/pkg/apis/messaging/v1alpha1/kinesis_channel_types.go
@@ -30,7 +30,7 @@ import (
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// KinesisChannel is a specification for a KinesisChannel resource
+// KinesisChannel is a specification for a KinesisChannel resource.
 type KinesisChannel struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -44,14 +44,14 @@ var _ apis.Validatable = (*KinesisChannel)(nil)
 var _ apis.Defaultable = (*KinesisChannel)(nil)
 var _ runtime.Object = (*KinesisChannel)(nil)
 
-// KinesisChannelSpec is the spec for a KinesisChannel resource
+// KinesisChannelSpec is the spec for a KinesisChannel resource.
 type KinesisChannelSpec struct {
 	eventingduckv1beta1.SubscribableSpec `json:",inline"`
 	AccountRegion                        string `json:"account_region"`
 	AccountCreds                         string `json:"account_creds"`
 }
 
-// KinesisChannelStatus is the status for a KinesisChannel resource
+// KinesisChannelStatus is the status for a KinesisChannel resource.
 type KinesisChannelStatus struct {
 	// inherits duck/v1beta1 Status, which currently provides:
 	// * ObservedGeneration - the 'Generation' of the Service that was last processed by the controller.
@@ -71,7 +71,7 @@ type KinesisChannelStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// KinesisChannelList is a list of KinesisChannel resources
+// KinesisChannelList is a list of KinesisChannel resources.
 type KinesisChannelList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
@@ -79,7 +79,7 @@ type KinesisChannelList struct {
 	Items []KinesisChannel `json:"items"`
 }
 
-// GetGroupVersionKind returns GroupVersionKind for KinesisChannels
+// GetGroupVersionKind returns GroupVersionKind for KinesisChannels.
 func (c *KinesisChannel) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("KinesisChannel")
 }

--- a/pkg/apis/messaging/v1alpha1/register.go
+++ b/pkg/apis/messaging/v1alpha1/register.go
@@ -24,18 +24,18 @@ import (
 	"github.com/triggermesh/aws-kinesis-channel/pkg/apis/messaging"
 )
 
-// SchemeGroupVersion is group version used to register these objects
+// SchemeGroupVersion is group version used to register these objects.
 var SchemeGroupVersion = schema.GroupVersion{
 	Group:   messaging.GroupName,
 	Version: "v1alpha1",
 }
 
-// Kind takes an unqualified kind and returns back a Group qualified GroupKind
+// Kind takes an unqualified kind and returns back a Group qualified GroupKind.
 func Kind(kind string) schema.GroupKind {
 	return SchemeGroupVersion.WithKind(kind).GroupKind()
 }
 
-// Resource takes an unqualified resource and returns a Group qualified GroupResource
+// Resource takes an unqualified resource and returns a Group qualified GroupResource.
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }

--- a/pkg/kinesisutil/kinesisutil.go
+++ b/pkg/kinesisutil/kinesisutil.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// Connect creates a new Kinesis-Streaming connection
+// Connect creates a new Kinesis-Streaming connection.
 func Connect(accountAccessKeyID, accountSecretAccessKey, region string, logger *zap.SugaredLogger) (*kinesis.Kinesis, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region:      aws.String(region),
@@ -41,14 +41,14 @@ func Connect(accountAccessKeyID, accountSecretAccessKey, region string, logger *
 	return kinesis.New(sess), nil
 }
 
-// Describe accepts kinesis client and stream name and returns kinesis stream description
+// Describe accepts kinesis client and stream name and returns kinesis stream description.
 func Describe(ctx context.Context, client *kinesis.Kinesis, streamName string) (*kinesis.DescribeStreamOutput, error) {
 	return client.DescribeStreamWithContext(ctx, &kinesis.DescribeStreamInput{
 		StreamName: &streamName,
 	})
 }
 
-// Create function creates kinesis stream
+// Create function creates kinesis stream.
 func Create(ctx context.Context, client *kinesis.Kinesis, streamName string) error {
 	_, err := client.CreateStreamWithContext(ctx, &kinesis.CreateStreamInput{
 		ShardCount: aws.Int64(1), // by now creating streams with only one shard.
@@ -57,7 +57,7 @@ func Create(ctx context.Context, client *kinesis.Kinesis, streamName string) err
 	return err
 }
 
-// Delete function deletes kinesis stream by its name
+// Delete function deletes kinesis stream by its name.
 func Delete(ctx context.Context, client *kinesis.Kinesis, streamName string) error {
 	_, err := client.DeleteStreamWithContext(ctx, &kinesis.DeleteStreamInput{
 		EnforceConsumerDeletion: aws.Bool(true), // by now creating streams with only one shard.
@@ -66,7 +66,7 @@ func Delete(ctx context.Context, client *kinesis.Kinesis, streamName string) err
 	return err
 }
 
-// Publish publishes msg to Kinesis stream
+// Publish publishes msg to Kinesis stream.
 func Publish(ctx context.Context, client *kinesis.Kinesis, streamName string, msg []byte, logger *zap.SugaredLogger) error {
 	_, err := client.PutRecordWithContext(ctx, &kinesis.PutRecordInput{
 		Data:         msg,
@@ -76,7 +76,7 @@ func Publish(ctx context.Context, client *kinesis.Kinesis, streamName string, ms
 	return err
 }
 
-// GetRecord retrieves one stream record by specified shard iterator
+// GetRecord retrieves one stream record by specified shard iterator.
 func GetRecord(client *kinesis.Kinesis, shardIterator *string) (*kinesis.GetRecordsOutput, error) {
 	return client.GetRecords(&kinesis.GetRecordsInput{
 		Limit:         aws.Int64(1),
@@ -84,16 +84,16 @@ func GetRecord(client *kinesis.Kinesis, shardIterator *string) (*kinesis.GetReco
 	})
 }
 
-// GetShardIterator returns "latest" shard iterator for specified stream
+// GetShardIterator returns "latest" shard iterator for specified stream.
 func GetShardIterator(ctx context.Context, client *kinesis.Kinesis, streamName *string) (*kinesis.GetShardIteratorOutput, error) {
 	res, err := client.DescribeStreamWithContext(ctx, &kinesis.DescribeStreamInput{
 		StreamName: streamName,
 	})
 	if err != nil || res.StreamDescription == nil {
-		return nil, fmt.Errorf("Kinesis stream description: %s", err)
+		return nil, fmt.Errorf("Kinesis stream description: %s", err) //nolint:stylecheck
 	}
 	if l := len(res.StreamDescription.Shards); l != 1 {
-		return nil, fmt.Errorf("Got %d shards, expected 1", l)
+		return nil, fmt.Errorf("got %d shards, expected 1", l)
 	}
 	t := kinesis.ShardIteratorTypeLatest
 	return client.GetShardIteratorWithContext(ctx, &kinesis.GetShardIteratorInput{

--- a/pkg/reconciler/controller/resources/dispatcher.go
+++ b/pkg/reconciler/controller/resources/dispatcher.go
@@ -38,15 +38,11 @@ type DispatcherArgs struct {
 	Image               string
 }
 
-// MakeDispatcher generates the dispatcher deployment for the Kinesis channel
+// MakeDispatcher generates the dispatcher deployment for the Kinesis channel.
 func MakeDispatcher(args DispatcherArgs) *appsv1.Deployment {
 	replicas := int32(1)
 
 	return &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployments",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dispatcherName,
 			Namespace: args.DispatcherNamespace,

--- a/pkg/reconciler/controller/resources/dispatcher_service.go
+++ b/pkg/reconciler/controller/resources/dispatcher_service.go
@@ -22,13 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// MakeDispatcherService creates the Kinesis dispatcher service
+// MakeDispatcherService creates the Kinesis dispatcher service.
 func MakeDispatcherService(namespace string) *corev1.Service {
 	return &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dispatcherName,
 			Namespace: namespace,

--- a/pkg/reconciler/controller/resources/service.go
+++ b/pkg/reconciler/controller/resources/service.go
@@ -63,10 +63,6 @@ func ExternalService(namespace, service string) ServiceOption {
 func MakeK8sService(kc *v1alpha1.KinesisChannel, opts ...ServiceOption) (*corev1.Service, error) {
 	// Add annotations
 	svc := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MakeChannelServiceName(kc.ObjectMeta.Name),
 			Namespace: kc.Namespace,

--- a/pkg/reconciler/controller/resources/service_account.go
+++ b/pkg/reconciler/controller/resources/service_account.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MakeServiceAccount creates a ServiceAccount
+// MakeServiceAccount creates a ServiceAccount.
 func MakeServiceAccount(namespace, name string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/stats_reporter.go
+++ b/pkg/reconciler/stats_reporter.go
@@ -123,7 +123,7 @@ type reporter struct {
 	ctx context.Context
 }
 
-// NewStatsReporter creates a reporter for reconcilers' metrics
+// NewStatsReporter creates a reporter for reconcilers' metrics.
 func NewStatsReporter(reconciler string) (StatsReporter, error) {
 	ctx, err := tag.New(
 		context.Background(),
@@ -134,7 +134,7 @@ func NewStatsReporter(reconciler string) (StatsReporter, error) {
 	return &reporter{ctx: ctx}, nil
 }
 
-// ReportServiceReady reports the time it took a service to become Ready
+// ReportServiceReady reports the time it took a service to become Ready.
 func (r *reporter) ReportReady(kind, namespace, service string, d time.Duration) error {
 	key := fmt.Sprintf("%s/%s", namespace, service)
 	v := int64(d / time.Millisecond)


### PR DESCRIPTION
Fixes everything reported by 
```console
$ golangci-lint run \
  --skip-dirs client \
  --enable-all \
  --disable wsl,funlen,lll,goerr113,whitespace,gochecknoinits,gochecknoglobals,godox,gomnd \
  ./pkg/...
```